### PR TITLE
fix: update publish directory to dist for Netlify static build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "corepack enable && corepack prepare pnpm@latest --activate && pnpm install --frozen-lockfile && pnpm run generate"
-  publish = ".output/public"
+  publish = "dist"
 
 [build.environment]
   NODE_VERSION = "20"


### PR DESCRIPTION
Netlify auto-detects and uses netlify-static preset which outputs to dist